### PR TITLE
Creating a custom footer to bring focus to the GitHub repo

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -9,7 +9,6 @@ export default function Footer(props) {
   return (
     <footer>
       <h2 className="sr-only">siteFooter</h2>
-      <div className="container mx-auto px-6 mt-5">{props.t.reportProblem}</div>
       <DateModified text={props.t.dateModified} />
       <div className="w-full">
         <div className="w-full h-auto bg-footer-parliament-image bg-no-repeat bg-right-bottom bg-[#173451]">
@@ -27,9 +26,18 @@ export default function Footer(props) {
                 return (
                   <li
                     key={index}
-                    className="text-white w-64 md:w-56 lg:w-80 my-2.5 hover:underline"
+                    className="text-white w-70 md:w-65 lg:w-80 my-2.5 hover:underline"
                   >
                     <a className="font-body" href={value.footerBoxlink}>
+                      <svg
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="w-10 h-10 inline-block mr-3"
+                        fill="currentColor"
+                        viewBox="0 0 16 16"
+                      >
+                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                      </svg>
                       {value.footerBoxLinkText}
                     </a>
                   </li>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -53,40 +53,16 @@ export default function Layout(props) {
         ]}
         footerBoxLinks={[
           {
-            footerBoxlink: t.footerContactUsURL,
-            footerBoxLinkText: t.footerContactUs,
+            footerBoxlink: t.footerContributeURL,
+            footerBoxLinkText: t.footerContribute,
           },
           {
-            footerBoxlink: t.footerNewsURL,
-            footerBoxLinkText: t.footerNews,
+            footerBoxlink: t.footerReportIssueURL,
+            footerBoxLinkText: t.footerReportIssue,
           },
           {
-            footerBoxlink: t.footerPmURL,
-            footerBoxLinkText: t.footerPm,
-          },
-          {
-            footerBoxlink: t.footerDepartmentAgenciesURL,
-            footerBoxLinkText: t.footerDepartmentAgencies,
-          },
-          {
-            footerBoxlink: t.footerTreatiesURL,
-            footerBoxLinkText: t.footerTreaties,
-          },
-          {
-            footerBoxlink: t.footerHowGovWorksURL,
-            footerBoxLinkText: t.footerHowGovWorks,
-          },
-          {
-            footerBoxlink: t.footerPublicServiceURL,
-            footerBoxLinkText: t.footerPublicService,
-          },
-          {
-            footerBoxlink: t.footerGovReportingURL,
-            footerBoxLinkText: t.footerGovReporting,
-          },
-          {
-            footerBoxlink: t.footerOpenGovURL,
-            footerBoxLinkText: t.footerOpenGov,
+            footerBoxlink: t.footerSuggestionURL,
+            footerBoxLinkText: t.footerSuggestion,
           },
         ]}
       />

--- a/locales/en.js
+++ b/locales/en.js
@@ -31,38 +31,19 @@ export default {
   //
   // Footer
   //
-  reportProblem: 'Report a problem',
   dateModified: 'Date Modified: ',
   // Landscape Links
 
-  footerContactUsURL: 'https://www.canada.ca/en/contact.html',
-  footerContactUs: 'Contact information',
+  footerContributeURL: 'https://github.com/DTS-STN/Scrum-Poker',
+  footerContribute: 'Contribute to this project',
 
-  footerNewsURL: 'https://www.canada.ca/en/news.html',
-  footerNews: 'News',
+  footerReportIssueURL:
+    'https://github.com/DTS-STN/Scrum-Poker/issues/new?title=Problem%20with%20site%3A%0A',
+  footerReportIssue: 'Report issues on this project',
 
-  footerPmURL: 'https://www.pm.gc.ca/en',
-  footerPm: 'Prime Minister',
-
-  footerDepartmentAgenciesURL: 'https://www.canada.ca/en/government/dept.html',
-  footerDepartmentAgencies: 'Department and agencies',
-
-  footerTreatiesURL: 'https://www.canada.ca/en/government/system/laws.html',
-  footerTreaties: 'Treaties, laws and regulations',
-
-  footerHowGovWorksURL:
-    'https://www.canada.ca/en/government/system/how-government-works.html',
-  footerHowGovWorks: 'How government works',
-
-  footerPublicServiceURL:
-    'https://www.canada.ca/en/government/publicservice.html',
-  footerPublicService: 'Public service and military',
-
-  footerGovReportingURL: 'https://www.canada.ca/en/transparency/reporting.html',
-  footerGovReporting: 'Government-wide reporting',
-
-  footerOpenGovURL: 'http://open.canada.ca/en',
-  footerOpenGov: 'Open government',
+  footerSuggestionURL:
+    'https://github.com/DTS-STN/Scrum-Poker/issues/new?title=Suggestion%3A%0A',
+  footerSuggestion: 'Suggest a change on this project',
 
   aboutgovernmentLink: 'https://www.canada.ca/en/government/system.html',
   aboutgovernmentText: 'About government',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -27,38 +27,19 @@ export default {
   //
   // Footer
   //
-  reportProblem: '(FR) Report a problem',
   dateModified: 'Date de modification : ',
   // Landscape Links
 
-  footerContactUsURL: 'https://www.canada.ca/fr/contact.html',
-  footerContactUs: 'Contactez-nous',
+  footerContributeURL: 'https://github.com/DTS-STN/Scrum-Poker',
+  footerContribute: 'Contribuer à ce projet',
 
-  footerNewsURL: 'https://www.canada.ca/fr/nouvelles.html',
-  footerNews: 'Nouvelles',
+  footerReportIssueURL:
+    'https://github.com/DTS-STN/Scrum-Poker/issues/new?title=Problem%20with%20site%3A%0A',
+  footerReportIssue: 'Signaler un problème',
 
-  footerPmURL: 'https://www.pm.gc.ca/fr',
-  footerPm: 'Premier ministre',
-
-  footerDepartmentAgenciesURL: 'https://www.canada.ca/fr/gouvernement/min.html',
-  footerDepartmentAgencies: 'Ministères et organismes',
-
-  footerTreatiesURL: 'https://www.canada.ca/fr/gouvernement/systeme/lois.html',
-  footerTreaties: 'Traités, lois et règlements',
-
-  footerHowGovWorksURL:
-    'https://www.canada.ca/fr/gouvernement/systeme/comment-gouvernement-fonctionne.html',
-  footerHowGovWorks: 'Comment le gouvernement fonctionne',
-
-  footerPublicServiceURL:
-    'https://www.canada.ca/fr/gouvernement/fonctionpublique.html',
-  footerPublicService: 'Service public et militaire',
-
-  footerGovReportingURL: 'https://www.canada.ca/fr/transparence/rapports.html',
-  footerGovReporting: "Rapports à l'échelle du gouvernement",
-
-  footerOpenGovURL: 'http://ouvert.canada.ca/',
-  footerOpenGov: 'Gouvernement ouvert',
+  footerSuggestionURL:
+    'https://github.com/DTS-STN/Scrum-Poker/issues/new?title=Suggestion%3A%0A',
+  footerSuggestion: 'Suggérer un changement',
 
   aboutgovernmentLink: 'https://www.canada.ca/fr/gouvernement/systeme.html',
   aboutgovernmentText: 'À propos du gouvernement',


### PR DESCRIPTION
no issue, of the cusp idea, posing as a suggestion.

### Description

List of proposed changes:

- This removes the standard GoC links in the blue footer to just those that point at our GitHub repo, in the spirit of open source work.
- This copies the idea taken from our own IT Accessibility pages https://bati-itao.github.io/index.html

### What to test for/How to test

### Additional Notes
