### PR TITLE
Added focus state, hover animation to cards

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -6,12 +6,14 @@ import Image from 'next/image'
 export default function Card(props) {
   return (
     <div
-      className={`h-auto w-48 mx-auto md:w-44 block ${
+      className={`h-auto w-48 mx-auto md:w-44 focus:rounded-lg focus:ring focus:ring-gray-600  ${
         props.selected
-          ? `border-4 border-canadaBlue rounded-lg`
-          : `border border-slate-300`
-      }`}
+          ? `border-4 border-canadaBlue rounded-lg focus:ring-0`
+          : `border border-slate-300 `
+      } ${props.className ? props.className : ``}`}
       onClick={props.onClick}
+      onKeyDown={props.onKeyDown}
+      tabIndex="0"
     >
       <Image
         id={props.id}
@@ -20,7 +22,6 @@ export default function Card(props) {
         width={74}
         height={102}
         layout="responsive"
-        className={props.className}
       ></Image>
     </div>
   )

--- a/components/Card.js
+++ b/components/Card.js
@@ -10,7 +10,7 @@ export default function Card(props) {
         props.selected
           ? `border-4 border-canadaBlue rounded-lg focus:ring-0`
           : `border border-slate-300 `
-      } ${props.className ? props.className : ``}`}
+      } ${props.className}`}
       onClick={props.onClick}
       onKeyDown={props.onKeyDown}
       tabIndex="0"

--- a/pages/room/[id].js
+++ b/pages/room/[id].js
@@ -17,6 +17,7 @@ export default function Room(props) {
     { id: 'card-8', src: '/Card_infinity.svg', alt: 'Card image', value: '∞' },
   ]
   const [selectedCard, setSelectedCard] = useState(null)
+
   return (
     <div
       id="roomContent"
@@ -43,7 +44,13 @@ export default function Room(props) {
               key={card.id}
               alt={card.alt}
               onClick={() => setSelectedCard(card)}
+              onKeyDown={(e) => {
+                if (e.keyCode === 32 || e.keyCode === 13) {
+                  setSelectedCard(card)
+                }
+              }}
               selected={card.id === selectedCard?.id}
+              className="hover:animate-pulsate-fwd"
             />
           )
         })}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,22 @@ module.exports = {
         current: 'currentColor',
         canadaBlue: '#1C578A',
       },
+      keyframes: {
+        'pulsate-fwd': {
+          '0%': {
+            transform: 'scale(1)',
+          },
+          '50%': {
+            transform: 'scale(1.02)',
+          },
+          '100%': {
+            transform: 'scale(1)',
+          },
+        },
+      },
+      animation: {
+        'pulsate-fwd': 'pulsate-fwd 1s ease-in-out infinite both',
+      },
       backgroundImage: () => ({
         'footer-parliament-image': 'url(../public/landscape.png)',
         // 'splash-page': 'url(../public/sp-bg-1.jpg)',


### PR DESCRIPTION
### [DUMS-54 - Make sure card component has defined styles for states (active, focus, hover)](https://jira-dev.bdm-dev.dts-stn.com/browse/DUMS-54) 
### [DUMS-53 - Explore use of animations when cards are clicked](https://jira-dev.bdm-dev.dts-stn.com/browse/DUMS-53)

### Description

This PR accomplishes a few things:

- Adds the cards to regular tab order for the purpose of adding a focus state to each card
- Cards can now be selected with either the space bar or the Enter key when focused and will properly update the `selected` state
- A custom pulsating animation has been added to the tailwind config which is being used whenever you hover over a card
- `className` has been removed from `Image` and instead is set conditionally in the parent div since css overrides weren't working when they were set on the `Image` itself

### What to test for/How to test

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/room/1`
4. Test the different states by hovering over the cards, tabbing through them hitting Enter or the space bar, and clicking them to ensure everything works properly
