### PR TITLE
Add current user and number of users to room info

### DIFF
--- a/pages/room/[id].js
+++ b/pages/room/[id].js
@@ -57,8 +57,8 @@ export default function Room(props) {
         id="rommid"
         t={t}
         roomId={props.roomId}
-        playerName="some name"
-        playersOnline="99"
+        playerName={currPlayer.playerName}
+        playersOnline={users.length}
       />
 
       {!selectedCard ? (


### PR DESCRIPTION
### Description

Since we have access to `currPlayer` and the dummy `users`, I've updated the roomInfo to use these.


### What to test for/How to test

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/room/abcde`
4. Ensure the Player name says `Numpty Numpty` and the number of players is 2