### PR TITLE
fixed nested li error

### DIFF
--- a/pages/room/[id].js
+++ b/pages/room/[id].js
@@ -75,19 +75,21 @@ export default function Room(props) {
       >
         {cards.map((card) => {
           return (
-            <Card
-              src={card.src}
-              id={card.id}
-              key={card.id}
-              alt={card.alt}
-              onClick={() => setSelectedCard(card)}
-              onKeyDown={(e) => {
-                if (e.keyCode === 32 || e.keyCode === 13) {
-                  setSelectedCard(card)
-                }
-              }}
-              selected={card.id === selectedCard?.id}
-            />
+            <li key={card.id}>
+              <Card
+                src={card.src}
+                id={card.id}
+                key={card.id}
+                alt={card.alt}
+                onClick={() => setSelectedCard(card)}
+                onKeyDown={(e) => {
+                  if (e.keyCode === 32 || e.keyCode === 13) {
+                    setSelectedCard(card)
+                  }
+                }}
+                selected={card.id === selectedCard?.id}
+              />
+            </li>
           )
         })}
       </ul>


### PR DESCRIPTION
## [DUMS-61](https://jira-dev.bdm-dev.dts-stn.com/browse/DUMS-61) (Jira Issue)

### Description
There was a warning about nested li tags when the cards were added to the list of players.

List of proposed changes:
wrapped each card in an li.



### What to test for/How to test
Add a card to the players list and make sure that there is no error.

### Additional Notes
