### PR TITLE
zap to only run on push to main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,8 +7,6 @@ name: Security - ZAP
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 # We have many jobs
 jobs:


### PR DESCRIPTION
## [DUMS-74](https://jira-dev.bdm-dev.dts-stn.com/browse/DUMS-74) (Jira Issue)

### Description
ZAP takes a long time to run on every PR

List of proposed changes:
ZAP will now run on every PR but only when it is approved and pushed to main.

-
-

### What to test for/How to test

### Additional Notes
