### PR TITLE
Changed reference from Room Id to Room Code

### DIFF
--- a/components/RoomInfo.js
+++ b/components/RoomInfo.js
@@ -267,7 +267,7 @@ RoomInfo.defaultProps = {
   playersOnline: 3,
   roomId: '2f3h9',
   t: {
-    roomId: 'Room Id:',
+    roomId: 'Room Code:',
     playerName: 'Player&apos;s Name:',
     playersOnline: 'Players Online:',
     copy: 'Copy',

--- a/locales/en.js
+++ b/locales/en.js
@@ -28,7 +28,7 @@ export default {
   showCards: 'Show',
   hideCards: 'Hide',
   clearCards: 'Clear',
-  roomId: 'Room Id:',
+  roomId: 'Room Code:',
   playerName: "Player's Name:",
   playersOnline: 'Players Online:',
   copy: 'Copy',


### PR DESCRIPTION

### Description

Changed the reference to 'Room Id' to 'Room Code' to match with all pages.

### What to test for/How to test

The meeting room should now say 'Room Code' to match the 'Room Code' reference on the previous page.

### Additional Notes
