### PR TITLE
Make selected card on home page easier to see

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -7,12 +7,14 @@ export default function Card(props) {
   return (
     <div
       className={`hover:cursor-pointer h-auto w-auto ${
-        props.homePage ? `rounded ` : `rounded-lg `
-      } focus:ring focus:ring-gray-600 ${
+        props.homePage
+          ? `rounded `
+          : `rounded-lg focus:ring focus:ring-gray-600`
+      } ${
         props.selected
           ? props.homePage
             ? `border-2 border-canadaBlue block rounded focus:ring-0 `
-            : `border-4 border-canadaBlue block rounded-lg focus:ring-0 `
+            : `border-4 border-canadaBlue block rounded focus:ring-0 `
           : props.className
           ? `h-auto w-14 p-1`
           : `border-1 border-slate-300 block hover:animate-pulsate-fwd`


### PR DESCRIPTION
## [Make selected card on home page easier to see-Task426](https://dev.azure.com/DTS-STN/Scrum%20Poker/_sprints/taskboard/Scrum%20Poker%20Team/Scrum%20Poker/Sprint%201?workitem=426)

### Description
Remove the highlighting on the home page cards to see if it's clearer to the user.

### What to test for/How to test
- Launch the app and go to the home page
- In the create room option, select and deselect card
- Make sure the cards are clear and that there isn't any highlighting making the card state a bit unclear
