### PR TITLE
rename attributes to fix refresh issue

### DIFF
--- a/components/CreateRoom.js
+++ b/components/CreateRoom.js
@@ -97,7 +97,6 @@ export default function CreateRoom(props) {
       if (addUserRes.data.addUser.success) {
         userid = addUserRes.data.addUser.id
         Cookies.set('userid', `${userid}`)
-        console.debug('Create room', userid, cardList)
       } else {
         throw t.saveUserFail
       }
@@ -127,6 +126,12 @@ export default function CreateRoom(props) {
         router.push({
           pathname: `/room/${addRoomRes.data.addRoom.id}`,
         })
+        console.log(
+          'Create room',
+          'Room id: ' + addRoomRes.data.addRoom.id,
+          'Username: ' + username,
+          'Card list: ' + JSON.stringify(cardList)
+        )
       }
     } catch (e) {
       console.log(e)

--- a/components/CreateRoom.js
+++ b/components/CreateRoom.js
@@ -97,6 +97,7 @@ export default function CreateRoom(props) {
       if (addUserRes.data.addUser.success) {
         userid = addUserRes.data.addUser.id
         Cookies.set('userid', `${userid}`)
+        console.debug('Create room', userid, cardList)
       } else {
         throw t.saveUserFail
       }

--- a/components/JoinRoom.js
+++ b/components/JoinRoom.js
@@ -83,7 +83,7 @@ export default function JoinRoom(props) {
       if (addUserRes.data.addUser.success) {
         userid = addUserRes.data.addUser.id
         Cookies.set('userid', `${userid}`)
-        console.debug('Join room', userid)
+        console.log('Join room', 'Username: ' + username, 'Room id: ' + room)
       } else {
         throw t.saveUserFail
       }

--- a/components/JoinRoom.js
+++ b/components/JoinRoom.js
@@ -83,6 +83,7 @@ export default function JoinRoom(props) {
       if (addUserRes.data.addUser.success) {
         userid = addUserRes.data.addUser.id
         Cookies.set('userid', `${userid}`)
+        console.debug('Join room', userid)
       } else {
         throw t.saveUserFail
       }

--- a/pages/room/[id].js
+++ b/pages/room/[id].js
@@ -73,7 +73,7 @@ export default function Room(props) {
       updateRoom({
         variables: {
           updateRoomId: room.id,
-          updateRoomUsers: room.userIds,
+          updateRoomUsers: room.users,
           isShown: false,
           cards: room.cards,
           timer: {
@@ -143,6 +143,7 @@ export default function Room(props) {
     variables: { room: props.roomId },
   })
   useEffect(() => {
+    console.log(roomSubscription)
     if (roomSubscription.data) {
       const { roomUpdated } = roomSubscription.data
       // check to see if a user was deleted
@@ -167,7 +168,7 @@ export default function Room(props) {
       const updatedRoomData = {
         id: roomUpdated.id,
         host: roomUpdated.host.id,
-        userIds: roomUpdated.users.map((user) => {
+        users: roomUpdated.users.map((user) => {
           return user.id
         }),
         isShown: roomUpdated.isShown,
@@ -217,8 +218,9 @@ export default function Room(props) {
   }
 
   const onBootClick = async (playerId) => {
+    console.log(room)
     let playerIdToRemove = playerId || userId
-    const index = room.userIds.indexOf(playerIdToRemove)
+    const index = room.users.indexOf(playerIdToRemove)
 
     // if (globalUserId === playerId) {
     //   router.push({
@@ -227,7 +229,7 @@ export default function Room(props) {
     // }
 
     if (index > -1) {
-      let copiedRoomUserIds = [...room.userIds]
+      let copiedRoomUserIds = [...room.users]
       copiedRoomUserIds.splice(index, 1)
       try {
         // remove user from room
@@ -326,7 +328,7 @@ export default function Room(props) {
                     updateRoom({
                       variables: {
                         updateRoomId: room.id,
-                        updateRoomUsers: room.userIds,
+                        updateRoomUsers: room.users,
                         isShown: true,
                         timer: {
                           timestamp: room.timer.timestamp,
@@ -454,7 +456,7 @@ export async function getServerSideProps({ params, locale }) {
   const room = {
     id: roomInfo.id,
     host: roomInfo.host.id,
-    userIds: roomInfo.users.map((user) => {
+    users: roomInfo.users.map((user) => {
       return user.id
     }),
     isShown: roomInfo.isShown,


### PR DESCRIPTION
## Task-542 (ADO)

### Description

List of proposed changes:
- attributes have been renamed to match the GraphQL schema 

### What to test for/How to test
- run the server and frontend locally
- create an instance of a room in different browsers (FF, Edge, Chrome, etc.)
- Attempt to boot users from the room, have users leave the room manually via the leave room button, enter messages in the chat
- the end result should be synchronization between all instances of the room, thus no manual refreshing of the UI is necessary
