### PR TITLE
add autocomplete=off to chat input

### DIFF
--- a/components/ChatRoom.js
+++ b/components/ChatRoom.js
@@ -105,6 +105,7 @@ export default function ChatRoom(props) {
               name={props.id}
               aria-label={props.t.placeHolder}
               placeholder={props.t.placeholder}
+              autoComplete="off"
               className="appearance-none rounded-md border-gray-400 border w-full my-2 p-1 text-gray-700 leading-tight focus:outline-none focus:drop-shadow focus:ring-2 focus:ring-inset focus:ring-gray-600"
             />
           </div>


### PR DESCRIPTION
##Task-540

### Description

List of proposed changes:
- autocomplete should be disabled on the chat input

### What to test for/How to test
- have the focus set inside of the chat input -> no autocomplete / suggestions should be brought up by the browser