### PR TITLE
fix sync issues with chat room

### DIFF
--- a/components/RoomInfo.js
+++ b/components/RoomInfo.js
@@ -26,6 +26,7 @@ const TimerSelect = (props) => {
         name="duration"
         id="duration-select"
         onChange={(e) => props.setDuration(parseFloat(e.target.value))}
+        defaultValue={props.duration / 60 / 1000}
       >
         {durationArray.map((duration, index) => (
           <option value={duration.value} key={index}>
@@ -44,6 +45,7 @@ const TimerContent = React.memo((props) => {
   if (props.isHost && props.timestamp === null) {
     return (
       <TimerSelect
+        duration={props.duration}
         setDuration={props.setDuration}
         timerLabels={props.timerLabels}
       />
@@ -76,7 +78,7 @@ const TimerButton = ({ buttonText, buttonType, handleStartTimerClick }) => {
   return (
     <button
       type="button"
-      className="w-auto px-2 ml-1 sm:text-base font-bold md:w-auto md:mt-0 sm:w-32 font-display ml-2 text-white bg-[#26374A] hover:bg-[#1C578A] active:bg-[#16446C] focus:bg-[#1C578A] rounded border border-[#091C2D] text-[12px]"
+      className="w-auto px-2 sm:text-base font-bold md:w-auto md:mt-0 sm:w-32 font-display ml-2 text-white bg-[#26374A] hover:bg-[#1C578A] active:bg-[#16446C] focus:bg-[#1C578A] rounded border border-[#091C2D] text-[12px]"
       onClick={() => handleStartTimerClick(buttonType)}
     >
       {buttonText}
@@ -123,7 +125,7 @@ export default function RoomInfo(props) {
   useEffect(() => {
     if (props.roomData.timer?.timestamp === null) {
       setButton(BUTTON_NAME.START)
-      setDuration(0.5)
+      setDuration(duration)
     }
   }, [props.roomData.timer])
 
@@ -136,8 +138,7 @@ export default function RoomInfo(props) {
       setButton(BUTTON_NAME.RESET)
     } else if (type === BUTTON_NAME.RESET.type) {
       timestamp = null
-      timerDuration = null
-      setDuration(0.5)
+      timerDuration = Number(duration)
       setButton(BUTTON_NAME.START)
     }
 
@@ -145,7 +146,7 @@ export default function RoomInfo(props) {
     props.updateRoom({
       variables: {
         updateRoomId: props.roomData.id,
-        updateRoomUsers: props.roomData.userIds,
+        updateRoomUsers: props.roomData.users,
         isShown: props.roomData.isShown,
         timer: {
           timestamp: timestamp ? timestamp.toString() : timestamp,

--- a/pages/room/[id].js
+++ b/pages/room/[id].js
@@ -73,7 +73,7 @@ export default function Room(props) {
       updateRoom({
         variables: {
           updateRoomId: room.id,
-          updateRoomUsers: room.userIds,
+          updateRoomUsers: room.users,
           isShown: false,
           cards: room.cards,
           timer: {
@@ -167,7 +167,7 @@ export default function Room(props) {
       const updatedRoomData = {
         id: roomUpdated.id,
         host: roomUpdated.host.id,
-        userIds: roomUpdated.users.map((user) => {
+        users: roomUpdated.users.map((user) => {
           return user.id
         }),
         isShown: roomUpdated.isShown,
@@ -218,7 +218,7 @@ export default function Room(props) {
 
   const onBootClick = async (playerId) => {
     let playerIdToRemove = playerId || userId
-    const index = room.userIds.indexOf(playerIdToRemove)
+    const index = room.users.indexOf(playerIdToRemove)
 
     // if (globalUserId === playerId) {
     //   router.push({
@@ -227,7 +227,7 @@ export default function Room(props) {
     // }
 
     if (index > -1) {
-      let copiedRoomUserIds = [...room.userIds]
+      let copiedRoomUserIds = [...room.users]
       copiedRoomUserIds.splice(index, 1)
       try {
         // remove user from room
@@ -326,7 +326,7 @@ export default function Room(props) {
                     updateRoom({
                       variables: {
                         updateRoomId: room.id,
-                        updateRoomUsers: room.userIds,
+                        updateRoomUsers: room.users,
                         isShown: true,
                         timer: {
                           timestamp: room.timer.timestamp,
@@ -347,7 +347,7 @@ export default function Room(props) {
                     updateRoom({
                       variables: {
                         updateRoomId: room.id,
-                        updateRoomUsers: room.userIds,
+                        updateRoomUsers: room.users,
                         isShown: false,
                         timer: {
                           timestamp: room.timer.timestamp,
@@ -454,7 +454,7 @@ export async function getServerSideProps({ params, locale }) {
   const room = {
     id: roomInfo.id,
     host: roomInfo.host.id,
-    userIds: roomInfo.users.map((user) => {
+    users: roomInfo.users.map((user) => {
       return user.id
     }),
     isShown: roomInfo.isShown,


### PR DESCRIPTION
## Task-542 + TASK-490 (ADO)

### Description

There were issues with synchronization between users in the chat room.  Removing a user from the room, would sometimes cause the UI to not re-render, forcing a manual refresh of the page to refresh the state.  The root cause of this issue was an incorrect variable name being passed to the GraphQL mutation in the client.

List of proposed changes:
- attributes have been renamed to match the GraphQL schema 
- changed the behaviour of resetting the timer -> now the timer uses the previous state instead of defaulting to 30 seconds upon reset.

### What to test for/How to test
- run the server and frontend locally
- create an instance of a room in different browsers (FF, Edge, Chrome, etc.)
- Attempt to boot users from the room, have users leave the room manually via the leave room button, enter messages in the chat
- the end result should be synchronization between all instances of the room, thus no manual refreshing of the UI is necessary
